### PR TITLE
Fix typo in README (s/task.loadNpmTasks/grunt.loadNpmTasks/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,18 @@
 [Grunt](https://github.com/cowboy/grunt) plugin for linting and minifying CSS
 
 ## Getting Started
+
 Install the module with: `npm install grunt-css`
 
-Then load it from your own grunt.js file:
+Then load it from your own `grunt.js` file:
 
-	task.loadNpmTasks('grunt-css');
+```js
+grunt.loadNpmTasks('grunt-css');
+```
 
 ## Documentation
 
-This plugin provides two tasks: `cssmin` and `csslint`, both .
-
-This task is a [multi task][types_of_tasks], meaning that grunt will automatically iterate over all `cssmin` and `csslint` targets if a target is not specified.
+This plugin provides two tasks: `cssmin` and `csslint`. Both area [multi tasks][types_of_tasks], meaning that grunt will automatically iterate over all `cssmin` and `csslint` targets if a target is not specified.
 
 [types_of_tasks]: https://github.com/cowboy/grunt/blob/master/docs/types_of_tasks.md
 
@@ -25,15 +26,17 @@ This works just like the [built-in `min` task, so check docs for that](https://g
 
 This is similar to the built-in lint task, though the configuration is different. Here's an example:
 
-	csslint: {
-		base_theme: {
-			src: "themes/base/*.css",
-			rules: {
-				"import": false,
-				"overqualified-elements": 2
-			}
+```js
+csslint: {
+	base_theme: {
+		src: "themes/base/*.css",
+		rules: {
+			"import": false,
+			"overqualified-elements": 2
 		}
 	}
+}
+```
 
 `src` specifies the files to lint, `rules` the rules to apply. A value of `false` ignores the rule, a value of `2` will set it to become an error. Otherwise all rules are considered warnings.
 
@@ -74,9 +77,12 @@ For an explanation of those rules, [check the csslint wiki](https://github.com/s
 
 *Side note: To update this list, run this:*
 
-	node -e "require('csslint').CSSLint.getRules().forEach(function(x) { console.log(x.id) })"
+```bash
+node -e "require('csslint').CSSLint.getRules().forEach(function(x) { console.log(x.id) })"
+```
 
 ## Contributing
+
 Please use the issue tracker and pull requests.
 
 ## Release History


### PR DESCRIPTION
Just happened to notice that typo. While I was editing the README anyway I took the liberty of adding syntax highlighting to the code blocks.
