### PR TITLE
Allows banner usage with cssmin task as in grunt built-in min task

### DIFF
--- a/tasks/grunt-css.js
+++ b/tasks/grunt-css.js
@@ -59,8 +59,18 @@ module.exports = function(grunt) {
   });
 
   grunt.registerMultiTask( "cssmin", "Minify CSS files with Sqwish.", function() {
+    // Get banner, if specified.
+    var banner = grunt.task.directive( this.file.src[0], function() {
+      return null;
+    });
+    if ( banner === null ) {
+      banner = '';
+    } else {
+      // Remove banner from src files as it is removed with minification (L73) anyway
+      this.file.src.shift();
+    }
     var max = grunt.helper( "concat", grunt.file.expandFiles( this.file.src ) );
-    var min = require( "sqwish" ).minify( max, false );
+    var min = banner + require( "sqwish" ).minify( max, false );
     grunt.file.write( this.file.dest, min );
     grunt.log.writeln( "File '" + this.file.dest + "' created." );
     grunt.helper( "min_max_info", min, max );


### PR DESCRIPTION
Currently, banner (if used) is removed by CSS minification.

This pull request solves this issue by concatenating the banner (if used) to the minified output.

Banner usage (same as with built-in min task):

```
cssmin: {
 dist: {
  // Use banner + file(s)
  src: ['<banner:meta.banner>', ... ],
  dest: ...
 }
}
```

Reference: https://github.com/cowboy/grunt/blob/master/tasks/min.js

Thank you for the grunt task by the way.
