### PR TITLE
Correct install instructions for grunt 0.3x 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Grunt](https://github.com/cowboy/grunt) plugin for linting and minifying CSS
 
-*Note: The current release (0.5.x) is not compatible with grunt 0.3.x, only with grunt 0.4.x. For grunt 0.3.x, use `npm install grunt-css@0.4.1`. Sorry about the mess.*
+*Note: The current release (0.5.x) is not compatible with grunt 0.3.x, only with grunt 0.4.x. For grunt 0.3.x, use `npm install grunt-css@0.3.2`. Sorry about the mess.*
 
 ## Getting Started
 


### PR DESCRIPTION
Iam using grunt in version v0.3.17

The indicated version grunt-css@0.4.1 would give me a TypeError, with tag 0.3.2 it works, just got an npm error while installing :

npm WARN package.json csslint@0.9.9 No README.md file found!

TypeError: Object #<Object> has no method 'options'
    at Object.module.exports (/htdocs/node_modules/grunt-css/tasks/grunt-css.js:74:24)
    at Object.task.registerMultiTask.thisTask (/htdocs/node_modules/grunt/lib/grunt/task.js:109:15)
    at Object.task.registerTask.thisTask.fn (/htdocs/node_modules/grunt/lib/grunt/task.js:58:16)
    at Task.<anonymous> (/htdocs/node_modules/grunt/lib/util/task.js:343:36)
    at Task.<anonymous> (/htdocs/node_modules/grunt/lib/util/task.js:319:9)
    at Task.<anonymous> (/htdocs/node_modules/grunt/lib/util/task.js:346:11)
    at Task.start (/htdocs/node_modules/grunt/lib/util/task.js:359:5)
    at Object.grunt.tasks (/htdocs/node_modules/grunt/lib/grunt.js:143:8)
    at Object.module.exports [as cli](/htdocs/node_modules/grunt/lib/grunt/cli.js:36:9)
    at Object.<anonymous> (/usr/local/lib/node_modules/grunt/bin/grunt:19:14)
