### PR TITLE
upgrade to css lint 0.9.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "clean-css": "0.9.1",
-    "csslint": "0.9.9",
+    "csslint": "0.9.10",
     "gzip-js": "0.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This includes support for parsing css calc() functions.
