### PR TITLE
Upgrade csslint dep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "clean-css": "0.9.1",
-    "csslint": "0.9.10",
+    "csslint": "0.10.0",
     "gzip-js": "0.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This is required to work on *BSD (specifically, Bitrig) but
should otherwise not make much difference.

I realize this package is deprecated, but I'm using a package that uses it.  While I plan on upgrading that package, this tiny PR would be very helpful for me so I can make it work with the original code first and then migrate it to a maintained package.
